### PR TITLE
Add GigaChat embeddings client with batching and retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ curl http://localhost:8080/
 - Put your OpenAPI spec at `openapi/gigachat.yml` (or adjust the path in `app/build.gradle.kts`).
 - Commands:
   - Generate only: `gradle :app:generateGigachatClient`
-  - Build with generation: `gradle :app:build`
+- Build with generation: `gradle :app:build`
 
 ## Docker
 
@@ -45,6 +45,22 @@ curl http://localhost:8080/
 docker build -t rag-dealer-chat:local -f app/Dockerfile .
 docker run --rm -p 8080:8080 --env-file .env.prod rag-dealer-chat:local
 ```
+
+## Embeddings
+
+The project provides a basic client for GigaChat embeddings. Create a
+`GigaChatEmbeddingsClient` with the generated OpenAPI `DefaultApi` and call
+`embed` with a list of texts:
+
+```java
+EmbeddingsClient client = new GigaChatEmbeddingsClient(api, "Embeddings", 64, 3,
+        Duration.ofSeconds(10));
+List<float[]> vectors = client.embed(List.of("first", "second"));
+```
+
+Supported models: `Embeddings` and `EmbeddingsGigaR`. Vector dimensionality
+depends on the selected model (see official documentation). The client batches
+requests and retries transient errors with exponential backoff.
 
 ### Temporary SSL bypass (dev only)
 

--- a/app/src/main/java/ru/kara4un/ragdealer/embeddings/GigaChatEmbeddingsClient.java
+++ b/app/src/main/java/ru/kara4un/ragdealer/embeddings/GigaChatEmbeddingsClient.java
@@ -1,0 +1,117 @@
+package ru.kara4un.ragdealer.embeddings;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import ru.kara4un.ragdealer.core.embeddings.EmbeddingsClient;
+import ru.kara4un.ragdealer.core.embeddings.EmbeddingsException;
+import ru.kara4un.ragdealer.gigachat.api.DefaultApi;
+import ru.kara4un.ragdealer.gigachat.invoker.ApiException;
+import ru.kara4un.ragdealer.gigachat.model.Embedding;
+import ru.kara4un.ragdealer.gigachat.model.EmbeddingDataInner;
+import ru.kara4un.ragdealer.gigachat.model.EmbeddingsBody;
+
+public class GigaChatEmbeddingsClient implements EmbeddingsClient {
+
+    private final DefaultApi api;
+    private final String model;
+    private final int batchMaxSize;
+    private final int maxAttempts;
+    private final Duration timeout;
+
+    public GigaChatEmbeddingsClient(
+            DefaultApi api,
+            String model,
+            int batchMaxSize,
+            int maxAttempts,
+            Duration timeout
+    ) {
+        this.api = api;
+        this.model = model;
+        this.batchMaxSize = batchMaxSize;
+        this.maxAttempts = maxAttempts;
+        this.timeout = timeout;
+        int ms = (int) timeout.toMillis();
+        api.getApiClient().setReadTimeout(ms);
+        api.getApiClient().setWriteTimeout(ms);
+        api.getApiClient().setConnectTimeout(ms);
+    }
+
+    @Override
+    public List<float[]> embed(List<String> texts) {
+        if (texts == null || texts.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<float[]> result = new ArrayList<>(Collections.nCopies(texts.size(), null));
+        int base = 0;
+        for (List<String> batch : chunk(texts, batchMaxSize)) {
+            EmbeddingsBody req = new EmbeddingsBody()
+                    .model(model)
+                    .input(batch);
+            Embedding resp = callWithRetry(() -> api.postEmbeddings(req));
+            for (EmbeddingDataInner d : resp.getData()) {
+                List<Float> vec = d.getEmbedding();
+                float[] fv = new float[vec.size()];
+                for (int i = 0; i < vec.size(); i++) {
+                    fv[i] = vec.get(i);
+                }
+                int targetIndex = base + d.getIndex();
+                result.set(targetIndex, fv);
+            }
+            base += batch.size();
+        }
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i) == null) {
+                throw new EmbeddingsException("Missing embedding at index " + i);
+            }
+        }
+        return result;
+    }
+
+    private static <T> List<List<T>> chunk(List<T> src, int size) {
+        List<List<T>> out = new ArrayList<>();
+        for (int i = 0; i < src.size(); i += size) {
+            out.add(src.subList(i, Math.min(i + size, src.size())));
+        }
+        return out;
+    }
+
+    private <T> T callWithRetry(SupplierWithException<T> supplier) {
+        long backoffMs = 200L;
+        Throwable last = null;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return supplier.get();
+            } catch (Throwable t) {
+                last = t;
+                if (attempt < maxAttempts && isRetriable(t)) {
+                    sleep(backoffMs);
+                    backoffMs = Math.min(backoffMs * 2, 5_000L);
+                    continue;
+                }
+                break;
+            }
+        }
+        throw new EmbeddingsException("Embeddings API failed after " + maxAttempts + " attempts", last);
+    }
+
+    private boolean isRetriable(Throwable t) {
+        if (t instanceof ApiException ae) {
+            int code = ae.getCode();
+            return code == 429 || (code >= 500 && code < 600);
+        }
+        return t instanceof java.io.IOException || (t.getCause() instanceof java.io.IOException);
+    }
+
+    private void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @FunctionalInterface
+    private interface SupplierWithException<T> { T get() throws Exception; }
+}

--- a/app/src/test/java/ru/kara4un/ragdealer/embeddings/GigaChatEmbeddingsClientTest.java
+++ b/app/src/test/java/ru/kara4un/ragdealer/embeddings/GigaChatEmbeddingsClientTest.java
@@ -1,0 +1,87 @@
+package ru.kara4un.ragdealer.embeddings;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ru.kara4un.ragdealer.gigachat.api.DefaultApi;
+import ru.kara4un.ragdealer.gigachat.invoker.ApiClient;
+
+public class GigaChatEmbeddingsClientTest {
+
+    private MockWebServer server;
+    private GigaChatEmbeddingsClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        ApiClient apiClient = new ApiClient();
+        apiClient.setBasePath(server.url("/").toString());
+        DefaultApi api = new DefaultApi(apiClient);
+        client = new GigaChatEmbeddingsClient(api, "Embeddings", 2, 3, Duration.ofSeconds(1));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    void embedsInBatches() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("{" +
+                        "\"data\":[{" +
+                        "\"embedding\":[0.1,0.2],\"index\":0},{" +
+                        "\"embedding\":[0.3,0.4],\"index\":1}]," +
+                        "\"model\":\"Embeddings\",\"object\":\"list\"}"));
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("{" +
+                        "\"data\":[{" +
+                        "\"embedding\":[0.5,0.6],\"index\":0}]," +
+                        "\"model\":\"Embeddings\",\"object\":\"list\"}"));
+        List<float[]> vectors = client.embed(List.of("a", "b", "c"));
+        assertEquals(3, vectors.size());
+        assertArrayEquals(new float[]{0.1f, 0.2f}, vectors.get(0));
+        assertArrayEquals(new float[]{0.3f, 0.4f}, vectors.get(1));
+        assertArrayEquals(new float[]{0.5f, 0.6f}, vectors.get(2));
+        assertEquals(2, server.getRequestCount());
+    }
+
+    @Test
+    void retriesOnTemporaryErrors() {
+        server.enqueue(new MockResponse().setResponseCode(500));
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("{" +
+                        "\"data\":[{" +
+                        "\"embedding\":[1.0],\"index\":0}]," +
+                        "\"model\":\"Embeddings\",\"object\":\"list\"}"));
+        List<float[]> vectors = client.embed(List.of("t"));
+        assertEquals(1, vectors.size());
+        assertEquals(2, server.getRequestCount());
+    }
+
+    @Test
+    void parsesFloatVectors() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("{" +
+                        "\"data\":[{" +
+                        "\"embedding\":[1.0,2.5],\"index\":0}]," +
+                        "\"model\":\"Embeddings\",\"object\":\"list\"}"));
+        List<float[]> vectors = client.embed(List.of("x"));
+        assertArrayEquals(new float[]{1.0f, 2.5f}, vectors.get(0));
+    }
+}

--- a/core/src/main/java/ru/kara4un/ragdealer/core/embeddings/EmbeddingsClient.java
+++ b/core/src/main/java/ru/kara4un/ragdealer/core/embeddings/EmbeddingsClient.java
@@ -1,0 +1,11 @@
+package ru.kara4un.ragdealer.core.embeddings;
+
+import java.util.List;
+
+public interface EmbeddingsClient {
+    /**
+     * Возвращает эмбеддинги для каждого входного текста.
+     * Размер результирующего списка равен размеру входного.
+     */
+    List<float[]> embed(List<String> texts);
+}

--- a/core/src/main/java/ru/kara4un/ragdealer/core/embeddings/EmbeddingsException.java
+++ b/core/src/main/java/ru/kara4un/ragdealer/core/embeddings/EmbeddingsException.java
@@ -1,0 +1,11 @@
+package ru.kara4un.ragdealer.core.embeddings;
+
+public class EmbeddingsException extends RuntimeException {
+    public EmbeddingsException(String message) {
+        super(message);
+    }
+
+    public EmbeddingsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
## Summary
- add core `EmbeddingsClient` interface and `EmbeddingsException`
- implement `GigaChatEmbeddingsClient` using generated GigaChat OpenAPI client with batching and retry
- cover embedding batches, retries, and float parsing in unit tests
- document embeddings usage in README

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a795d721248333ac7b97c70d7bb42f